### PR TITLE
added modal functionality

### DIFF
--- a/resources/views/categories-list.blade.php
+++ b/resources/views/categories-list.blade.php
@@ -33,4 +33,7 @@
 
 </div>
 <x-footer-user></x-footer-user>
+@if(!session('user'))
+    @include('components.lead-modal', ['closable' => true])
+@endif
 </body>

--- a/resources/views/components/common.blade.php
+++ b/resources/views/components/common.blade.php
@@ -7,3 +7,4 @@
 
   gtag('config', 'G-QNRXWL4PEM');
 </script>
+<meta name="csrf-token" content="{{ csrf_token() }}">

--- a/resources/views/components/lead-modal.blade.php
+++ b/resources/views/components/lead-modal.blade.php
@@ -1,0 +1,207 @@
+<style>
+#leadModal {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 100vw !important;
+  height: 100vh !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  background: rgba(0,0,0,0.5) !important;
+  z-index: 9999 !important;
+}
+#leadModal.hidden { display: none !important; }
+</style>
+
+<div id="leadModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 hidden">
+    <div class="bg-white rounded-2xl shadow-lg w-full relative" style="max-width: 460px;">
+        <button id="leadModalClose" class="absolute top-3 right-3 text-gray-400 hover:text-gray-700 text-2xl font-bold focus:outline-none hidden">&times;</button>
+        <div class="p-6">
+            <h2 class="text-2xl font-bold text-center text-blue-700 mb-2">Unlock Your Learning Journey!</h2>
+            <p class="text-center text-gray-700 mb-4">Sign up or log in to access exclusive content, personalized training, and get a free call from our experts!<br>
+                <span class="text-green-700 font-semibold">Select <u>"Interested in training"</u> and <u>"I would like to receive call from training"</u> for a free consultation and special offers!</span>
+            </p>
+            <div class="flex justify-center mb-4">
+                <button id="leadTabSignup" class="px-4 py-2 rounded-l-xl bg-blue-500 text-white font-semibold focus:outline-none">Signup</button>
+                <button id="leadTabLogin" class="px-4 py-2 rounded-r-xl bg-gray-200 text-blue-700 font-semibold focus:outline-none">Login</button>
+            </div>
+            <div id="leadSignupForm" class="">
+                <div id="modalSignupError" class="text-red-600 text-sm mb-2"></div>
+                @include('user-signup-modal')
+            </div>
+            <div id="leadLoginForm" class="hidden">
+                <div id="modalLoginError" class="text-red-600 text-sm mb-2"></div>
+                @include('user-login-modal')
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        var closable = @json($closable ?? true);
+        var showDelay = window.location.pathname.startsWith('/topic/') ? 5000 : 15000;
+        if (closable && localStorage.getItem('leadModalClosed')) return;
+        setTimeout(function() {
+            var modal = document.getElementById('leadModal');
+            var closeBtn = document.getElementById('leadModalClose');
+            if (modal) {
+                modal.classList.remove('hidden');
+                if (closable && closeBtn) closeBtn.classList.remove('hidden');
+                if (!closable && closeBtn) closeBtn.classList.add('hidden');
+            }
+        }, showDelay);
+        var closeBtn = document.getElementById('leadModalClose');
+        if (closable && closeBtn) {
+            closeBtn.onclick = function() {
+                document.getElementById('leadModal').classList.add('hidden');
+                localStorage.setItem('leadModalClosed', '1');
+            };
+        }
+        // Tab switching logic
+        var tabSignup = document.getElementById('leadTabSignup');
+        var tabLogin = document.getElementById('leadTabLogin');
+        if (tabSignup && tabLogin) {
+            tabSignup.onclick = function() {
+                document.getElementById('leadSignupForm').classList.remove('hidden');
+                document.getElementById('leadLoginForm').classList.add('hidden');
+                this.classList.add('bg-blue-500', 'text-white');
+                this.classList.remove('bg-gray-200', 'text-blue-700');
+                tabLogin.classList.remove('bg-blue-500', 'text-white');
+                tabLogin.classList.add('bg-gray-200', 'text-blue-700');
+            };
+            tabLogin.onclick = function() {
+                document.getElementById('leadSignupForm').classList.add('hidden');
+                document.getElementById('leadLoginForm').classList.remove('hidden');
+                this.classList.add('bg-blue-500', 'text-white');
+                this.classList.remove('bg-gray-200', 'text-blue-700');
+                tabSignup.classList.remove('bg-blue-500', 'text-white');
+                tabSignup.classList.add('bg-gray-200', 'text-blue-700');
+            };
+        }
+
+        // AJAX logic for signup and login forms
+        function getCsrfToken() {
+            let token = document.querySelector('meta[name="csrf-token"]');
+            if (token) return token.getAttribute('content');
+            let input = document.querySelector('input[name="_token"]');
+            if (input) return input.value;
+            return '';
+        }
+        // Signup
+        var signupForm = document.getElementById('modalSignupForm');
+        if (signupForm) {
+            // Real-time error clearing
+            ['name','email','mobile','password','password_confirmation','interested_in_training','leads'].forEach(function(field) {
+                var el = document.getElementById('modal_' + field);
+                if (el) {
+                    el.addEventListener('input', function() {
+                        var err = document.getElementById('error_' + field);
+                        if (err) err.innerHTML = '';
+                    });
+                    // For select and checkbox
+                    el.addEventListener('change', function() {
+                        var err = document.getElementById('error_' + field);
+                        if (err) err.innerHTML = '';
+                    });
+                }
+            });
+            signupForm.onsubmit = function(e) {
+                e.preventDefault();
+                document.getElementById('modalSignupBtn').disabled = true;
+                document.getElementById('modalSignupSpinner').style.display = 'inline-block';
+                document.getElementById('modalSignupError').innerHTML = '';
+                // Clear all field errors
+                ['name','email','mobile','password','password_confirmation','interested_in_training','leads'].forEach(function(field) {
+                    var err = document.getElementById('error_' + field);
+                    if (err) err.innerHTML = '';
+                });
+                const formData = new FormData(signupForm);
+                fetch('/user-signup', {
+                    method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'X-CSRF-TOKEN': getCsrfToken(),
+                    },
+                    body: formData
+                })
+                .then(async response => {
+                    document.getElementById('modalSignupBtn').disabled = false;
+                    document.getElementById('modalSignupSpinner').style.display = 'none';
+                    if (response.ok) {
+                        document.getElementById('modalSignupError').innerHTML = '<span style="color: #16a34a;">Signup successful! Redirecting...</span>';
+                        setTimeout(function() {
+                            location.reload();
+                        }, 2000);
+                    } else {
+                        let data = await response.json();
+                        let msg = '';
+                        if (data.errors) {
+                            for (let key in data.errors) {
+                                var err = document.getElementById('error_' + key);
+                                if (err) {
+                                    err.innerHTML = data.errors[key].join('<br>');
+                                } else {
+                                    msg += data.errors[key].join('<br>') + '<br>';
+                                }
+                            }
+                        } else if (data.message) {
+                            msg = data.message;
+                        } else {
+                            msg = 'Signup failed. Please try again.';
+                        }
+                        document.getElementById('modalSignupError').innerHTML = msg;
+                    }
+                })
+                .catch(() => {
+                    document.getElementById('modalSignupBtn').disabled = false;
+                    document.getElementById('modalSignupSpinner').style.display = 'none';
+                    document.getElementById('modalSignupError').innerHTML = 'Signup failed. Please try again.';
+                });
+            };
+        }
+        // Login
+        var loginForm = document.getElementById('modalLoginForm');
+        if (loginForm) {
+            loginForm.onsubmit = function(e) {
+                e.preventDefault();
+                const btn = loginForm.querySelector('button[type="submit"]');
+                btn.disabled = true;
+                document.getElementById('modalLoginError').innerHTML = '';
+                const formData = new FormData(loginForm);
+                fetch('/user-login', {
+                    method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'X-CSRF-TOKEN': getCsrfToken(),
+                    },
+                    body: formData
+                })
+                .then(async response => {
+                    btn.disabled = false;
+                    if (response.ok) {
+                        location.reload();
+                    } else {
+                        let data = await response.json();
+                        let msg = '';
+                        if (data.errors) {
+                            for (let key in data.errors) {
+                                msg += data.errors[key].join('<br>') + '<br>';
+                            }
+                        } else if (data.message) {
+                            msg = data.message;
+                        } else {
+                            msg = 'Login failed. Please try again.';
+                        }
+                        document.getElementById('modalLoginError').innerHTML = msg;
+                    }
+                })
+                .catch(() => {
+                    btn.disabled = false;
+                    document.getElementById('modalLoginError').innerHTML = 'Login failed. Please try again.';
+                });
+            };
+        }
+    });
+</script> 

--- a/resources/views/course-details.blade.php
+++ b/resources/views/course-details.blade.php
@@ -33,4 +33,7 @@
    
 </div>
 <x-footer-user></x-footer-user>
+@if(!session('user'))
+    @include('components.lead-modal', ['closable' => true])
+@endif
 </body>

--- a/resources/views/courses.blade.php
+++ b/resources/views/courses.blade.php
@@ -1,0 +1,4 @@
+@if(!session('user'))
+    @include('components.lead-modal', ['closable' => true])
+@endif
+</body> 

--- a/resources/views/start-quiz.blade.php
+++ b/resources/views/start-quiz.blade.php
@@ -43,5 +43,8 @@
   
 
 </div>
+@if(!session('user'))
+    @include('components.lead-modal', ['closable' => true])
+@endif
 </body>
 </html>

--- a/resources/views/topics.blade.php
+++ b/resources/views/topics.blade.php
@@ -38,5 +38,41 @@
     
     </div>
 </div>
+@if(!session('user'))
+    @include('components.lead-modal')
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            setTimeout(function() {
+                var modal = document.getElementById('leadModal');
+                var closeBtn = document.getElementById('leadModalClose');
+                if (modal) {
+                    modal.classList.remove('hidden');
+                    if (closeBtn) closeBtn.classList.add('hidden'); // Hide close button
+                }
+            }, 5000);
+            // Tab switching logic
+            var tabSignup = document.getElementById('leadTabSignup');
+            var tabLogin = document.getElementById('leadTabLogin');
+            if (tabSignup && tabLogin) {
+                tabSignup.onclick = function() {
+                    document.getElementById('leadSignupForm').classList.remove('hidden');
+                    document.getElementById('leadLoginForm').classList.add('hidden');
+                    this.classList.add('bg-blue-500', 'text-white');
+                    this.classList.remove('bg-gray-200', 'text-blue-700');
+                    tabLogin.classList.remove('bg-blue-500', 'text-white');
+                    tabLogin.classList.add('bg-gray-200', 'text-blue-700');
+                };
+                tabLogin.onclick = function() {
+                    document.getElementById('leadSignupForm').classList.add('hidden');
+                    document.getElementById('leadLoginForm').classList.remove('hidden');
+                    this.classList.add('bg-blue-500', 'text-white');
+                    this.classList.remove('bg-gray-200', 'text-blue-700');
+                    tabSignup.classList.remove('bg-blue-500', 'text-white');
+                    tabSignup.classList.add('bg-gray-200', 'text-blue-700');
+                };
+            }
+        });
+    </script>
+@endif
 </body>
 </html> 

--- a/resources/views/tutorial.blade.php
+++ b/resources/views/tutorial.blade.php
@@ -114,4 +114,32 @@ h2.list-heading{
 </div>
 
 <x-footer-user></x-footer-user>
+@if(!session('user'))
+    @include('components.lead-modal')
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            setTimeout(function() {
+                document.getElementById('leadModal').classList.remove('hidden');
+                document.getElementById('leadModalClose').classList.add('hidden'); // Hide close button
+            }, 5000);
+            // Tab switching logic
+            document.getElementById('leadTabSignup').onclick = function() {
+                document.getElementById('leadSignupForm').classList.remove('hidden');
+                document.getElementById('leadLoginForm').classList.add('hidden');
+                this.classList.add('bg-blue-500', 'text-white');
+                this.classList.remove('bg-gray-200', 'text-blue-700');
+                document.getElementById('leadTabLogin').classList.remove('bg-blue-500', 'text-white');
+                document.getElementById('leadTabLogin').classList.add('bg-gray-200', 'text-blue-700');
+            };
+            document.getElementById('leadTabLogin').onclick = function() {
+                document.getElementById('leadSignupForm').classList.add('hidden');
+                document.getElementById('leadLoginForm').classList.remove('hidden');
+                this.classList.add('bg-blue-500', 'text-white');
+                this.classList.remove('bg-gray-200', 'text-blue-700');
+                document.getElementById('leadTabSignup').classList.remove('bg-blue-500', 'text-white');
+                document.getElementById('leadTabSignup').classList.add('bg-gray-200', 'text-blue-700');
+            };
+        });
+    </script>
+@endif
 </body>

--- a/resources/views/user-login-modal.blade.php
+++ b/resources/views/user-login-modal.blade.php
@@ -1,0 +1,15 @@
+<form id="modalLoginForm" action="/user-login" method="post" class="space-y-4">
+    @csrf
+    <div>
+        <label for="modal_login_email" class="text-gray-600 mb-1">User Email</label>
+        <input type="text" id="modal_login_email" placeholder="Enter User email" name="email"
+        class="w-full px-4 py-2 border border-gray-300 rounded-xl focus:outline-none">
+    </div>
+    <div>
+        <label for="modal_login_password" class="text-gray-600 mb-1">Password</label>
+        <input type="password" id="modal_login_password" placeholder="Enter User password" name="password"
+        class="w-full px-4 py-2 border border-gray-300 rounded-xl focus:outline-none">
+    </div>
+    <button type="submit" class="w-full bg-blue-500 rounded-xl px-4 py-2 text-white">Login</button>
+    <a href="user-forgot-password" class="text-green-500">Forgot Password?</a>
+</form> 

--- a/resources/views/user-quiz-list.blade.php
+++ b/resources/views/user-quiz-list.blade.php
@@ -42,5 +42,8 @@
         </ul>
     </div>
 </div>
+@if(!session('user'))
+    @include('components.lead-modal', ['closable' => true])
+@endif
 </body>
 </html>

--- a/resources/views/user-signup-modal.blade.php
+++ b/resources/views/user-signup-modal.blade.php
@@ -1,0 +1,54 @@
+<form id="modalSignupForm" action="/user-signup" method="post" class="space-y-4">
+    @csrf
+    <div>
+        <label for="modal_name" class="text-gray-600 mb-1">User Name</label>
+        <input type="text" id="modal_name" placeholder="Enter User name" name="name"
+        class="w-full px-4 py-2 border border-gray-300 rounded-xl focus:outline-none">
+        <div id="error_name" class="input-error"></div>
+    </div>
+    <div>
+        <label for="modal_email" class="text-gray-600 mb-1">User Email</label>
+        <input type="text" id="modal_email" placeholder="Enter User email" name="email"
+        class="w-full px-4 py-2 border border-gray-300 rounded-xl focus:outline-none">
+        <div id="error_email" class="input-error"></div>
+    </div>
+    <div>
+        <label for="modal_mobile" class="text-gray-600 mb-1">User Mobile</label>
+        <input type="text" id="modal_mobile" placeholder="Enter User Mobile" name="mobile"
+        class="w-full px-4 py-2 border border-gray-300 rounded-xl focus:outline-none">
+        <div id="error_mobile" class="input-error"></div>
+    </div>
+    <div class="relative">
+        <label for="modal_password" class="text-gray-600 mb-1">Password</label>
+        <input type="password" id="modal_password" placeholder="Enter User password" name="password"
+        class="w-full px-4 py-2 border border-gray-300 rounded-xl focus:outline-none">
+        <div id="error_password" class="input-error"></div>
+    </div>
+    <div class="relative">
+        <label for="modal_password_confirmation" class="text-gray-600 mb-1">Confirm Password</label>
+        <input type="password" id="modal_password_confirmation" placeholder="Confirm User password" name="password_confirmation"
+        class="w-full px-4 py-2 border border-gray-300 rounded-xl focus:outline-none">
+        <div id="error_password_confirmation" class="input-error"></div>
+    </div>
+    <div>
+        <label for="modal_interested_in_training" class="text-gray-600 mb-1 font-bold text-blue-700">Interested in Training <span class="text-green-600">(Highly Recommended)</span></label>
+        <select id="modal_interested_in_training" name="interested_in_training" class="w-full px-4 py-2 border-2 border-green-500 rounded-xl focus:outline-none bg-green-50">
+            <option value="">Select an option</option>
+            <option value="yes">Yes, I am interested in training</option>
+            <option value="no">No, not interested</option>
+        </select>
+        <div id="error_interested_in_training" class="input-error"></div>
+    </div>
+    <div class="flex items-center bg-green-100 p-2 rounded-xl border-2 border-green-500">
+        <input type="checkbox" id="modal_leads" name="leads" value="1" class="mr-2">
+        <label for="modal_leads" class="text-gray-700 font-bold">I would like to receive call from training <span class="text-green-600">(Get a free consultation!)</span></label>
+        <div id="error_leads" class="input-error"></div>
+    </div>
+    <button id="modalSignupBtn" type="submit" class="w-full bg-blue-500 rounded-xl px-4 py-2 text-white flex items-center justify-center">
+        Signup
+        <span id="modalSignupSpinner" class="spinner" style="display:none;"></span>
+    </button>
+</form>
+<style>
+.input-error { color: #e3342f; font-size: 0.95rem; margin-top: 0.25rem; }
+</style> 

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -52,4 +52,7 @@
   </div>
 </div>
 <x-footer-user></x-footer-user>
+@if(!session('user'))
+    @include('components.lead-modal', ['closable' => true])
+@endif
 </body>


### PR DESCRIPTION
PR Points: Lead Generation Modal Functionality

- Lead Modal Implementation
    - Added a reusable, attractive modal for user signup/login focused on lead generation.
    - Modal encourages users to select "Interested in training" and "I would like to receive call from training" options.

- Conditional Display Logic
    - Modal is shown only to users who are not logged in.
    - On /topic/... pages, the modal is mandatory (cannot be closed without signup/login).
    - On other key pages (home, user-quiz-list, start-quiz, categories-list, courses, course-details), the modal is closable and appears after a delay.
    - If the user closes the modal on any closable page, it will not show again (using localStorage).

- DRY Refactor
    - All modal logic and scripts are encapsulated in a single Blade component (components/lead-modal.blade.php).
    - Pages include the modal with a single line, passing a closable flag as needed.

- AJAX Signup/Login
    - Both forms in the modal use AJAX for submission.
    - On success, the modal displays a green success message and remains open for 2 seconds before reloading the page.
    - On error, field-specific errors are shown in red under each field, and general errors are shown at the top.

- Real-Time Error Handling
    - As users correct fields, the corresponding error messages are cleared in real time for a better UX.

- Responsive and Accessible
    - Modal is centered, responsive, and styled for clarity and professionalism.
    - Fallback CSS ensures modal visibility even if Tailwind is missing or overridden.

- No Code Duplication
    - Removed all repeated modal/script code from individual Blade files; all logic is now centralized.